### PR TITLE
Fixed a minor indentation problem

### DIFF
--- a/servers/pycl.py
+++ b/servers/pycl.py
@@ -36,13 +36,13 @@ class Handler(BaseHTTPRequestHandler):
 	global temp_has_delete
 
 	def do_GET(self):
-	if self.path == '/status':
-		self.send_response(200)
-		self.send_header('Content-Type', 'text/plain; charset=utf-8')
-		self.end_headers()
-		self.wfile.write('edit-server is running.\n')
-		return
-	self.send_error(404, "GET Not Found: %s" % self.path)
+		if self.path == '/status':
+		  self.send_response(200)
+		  self.send_header('Content-Type', 'text/plain; charset=utf-8')
+		  self.end_headers()
+		  self.wfile.write('edit-server is running.\n')
+		  return
+	  self.send_error(404, "GET Not Found: %s" % self.path)
 
 	def do_POST(self):
 		global processes


### PR DESCRIPTION
I've been using Edit with Emacs to edit textareas (with Vim... heh). I was using quite an old copy, and patched it to add the domain name to the temporary filename so that my filetype.vim script would pick up, say "wikipedia.org" and use that to apply the MediaWiki syntax mode.

I downloaded the Git repository and what do I see: you've already implemented it! Awesome!

I run it and there's an error because of indentation. I've fixed that in this commit.

Thanks for the extension! It's made the transition from Firefox to Chrome significantly less painful!
