### PR TITLE
Make new frame under OS X Emacsen other than Aquamacs

### DIFF
--- a/servers/edit-server.el
+++ b/servers/edit-server.el
@@ -326,7 +326,8 @@ If `edit-server-verbose' is non-nil, then STRING is also echoed to the message l
 	"Create a frame for the edit server"
 	(if edit-server-new-frame
 			(let ((new-frame
-						 (if (featurep 'aquamacs)
+						 (if (memq window-system '(ns mac))
+								 ;; Aquamacs, Emacs NS, Emacs (experimental) Mac port
 								 (make-frame edit-server-new-frame-alist)
 							 (make-frame-on-display (getenv "DISPLAY")
 																			edit-server-new-frame-alist))))


### PR DESCRIPTION
(featurep 'aquamacs) was false for me on the experimental Emacs Mac
port, causing edit-server to fail since make-frame-on-display seems to
only work when you're under X11.  I presume--but have not tested--that
it would also fail for the official Emacs NS port.

This new test on window-system should cover Aquamacs (tested), Emacs
NS port (untested), and the Emacs Mac port (tested).
