### PR TITLE
Add debug setting and suppress console.log when debug not enabled

### DIFF
--- a/fancy-settings/source/i18n.js
+++ b/fancy-settings/source/i18n.js
@@ -72,5 +72,9 @@ this.i18n = {
     "disconnect": {
         "en": "Disconnect:",
         "de": "Trennen:"
+    },
+    "enable_debug": {
+        "en": "Enable debug (logs to the console)",
+        "de": "Debug (Protokolle an die Konsole)"
     }
 };

--- a/fancy-settings/source/manifest.js
+++ b/fancy-settings/source/manifest.js
@@ -52,6 +52,13 @@ this.manifest = {
             "type": "button",
             "label": i18n.get("Test Edit Server"),
 	    "text": i18n.get("Test")
+        },
+        {
+            "tab": "Test",
+            "group": "Test",
+            "name": "enable_debug",
+            "type": "checkbox",
+            "label": i18n.get("enable_debug")
         }
     ]
 };

--- a/textareas.js
+++ b/textareas.js
@@ -25,6 +25,16 @@ var findTextAreasDefferedElements = [];
 var enable_button = true;
 var enable_dblclick = false;
 var enable_keys = false;
+var enable_debug = false;
+
+// Decorate console.log so that it only logs
+// when the enable_debug setting is true
+var orig_console_log = console.log;
+console.log = function() {
+    if (enable_debug) {
+        orig_console_log.apply(console, Array.prototype.slice.call(arguments));
+    }
+};
 
 /*
   getTitle
@@ -344,6 +354,7 @@ function localMessageHandler(msg, port) {
 		enable_button = msg.enable_button;
 		enable_dblclick = msg.enable_dblclick;
 		enable_keys = msg.enable_keys;
+		enable_debug = msg.enable_debug;
 		findTextAreas([$('*')]);
 		document.addEventListener("DOMNodeInserted", (function (ev) {
 			handleInsertedElements(ev);

--- a/xmlcomms.js
+++ b/xmlcomms.js
@@ -16,7 +16,8 @@ var settings = new Store("settings", {
     "edit_server_port": 9292,
     "enable_button": true,
     "enable_dblclick": false,
-    "enable_keys": false
+    "enable_keys": false,
+    "enable_debug": false
 });
 
 
@@ -157,7 +158,8 @@ function handleConfigMessages(msg, tab_port)
 	    msg: "config",
 	    enable_button: settings.get("enable_button"),
 	    enable_dblclick: settings.get("enable_dblclick"),
-	    enable_keys: settings.get("enable_keys")
+	    enable_keys: settings.get("enable_keys"),
+	    enable_debug: settings.get("enable_debug")
 	};
 	tab_port.postMessage(config_msg);
 }


### PR DESCRIPTION
The enable_debug option is presented in the settings page under the Test
tab. Set to false by default which suppresses the console.log messages.

The console.log messages are suppressed by decorating the console.log
function to include a check to see if the enable_debug option is true
before logging.

As requested this is a single commit with only functional changes.

Cheers,

Matt.
