### PR TITLE
Use UTF-8 coding for process communication

### DIFF
--- a/servers/edit-server.el
+++ b/servers/edit-server.el
@@ -265,15 +265,17 @@ will cause it to be verbose."
   (interactive "P")
   (if (or (process-status "edit-server")
 	  (null (condition-case err
-		    (make-network-process
-		     :name "edit-server"
-		     :buffer edit-server-process-buffer-name
-		     :family 'ipv4
-		     :host (or edit-server-host 'local)
-		     :service edit-server-port
-		     :log 'edit-server-accept
-		     :server t
-		     :noquery t)
+                    (let ((proc (make-network-process
+                                 :name "edit-server"
+                                 :buffer edit-server-process-buffer-name
+                                 :family 'ipv4
+                                 :host (or edit-server-host 'local)
+                                 :service edit-server-port
+                                 :log 'edit-server-accept
+                                 :server t
+                                 :noquery t)))
+                      (set-process-coding-system proc 'utf-8 'utf-8)
+                      proc)
 		  (file-error nil))))
       (message "An edit-server process is already running")
     (setq edit-server-clients '())


### PR DESCRIPTION
This prevents  misinterpretation of multibyte UTF-8 coding, like  `ã`or `ç`  in the generated edit buffer. An alternative would be to force the user that wants this to set `default-process-coding-system` to `(utf-8 . utf-8)`, but since edit-server.el already mentions utf-8 in it, I decided this is useful (at least for me).

I didn't test it, but this probably also makes the use of `(encode-coding-string ... 'utf-8)` obsolote, and those could be simplified.
