### PR TITLE
Send textInput event after updating text

### DIFF
--- a/textareas.js
+++ b/textareas.js
@@ -208,6 +208,13 @@ function updateTextArea(id, content) {
 		event.initEvent('change', true, false);
 		tracker.text.dispatchEvent(event);
 
+		// set selection to after end of the text
+		tracker.text.selectionStart = content.length;
+		// send a textInputEvent to append a newline
+		event = document.createEvent("TextEvent");
+		event.initTextEvent('textInput', true, true, null, '\n', 0);
+		tracker.text.dispatchEvent(event);
+
 		setTimeout(function(){
 			$(tracker.text).animate({ 'backgroundColor': orig }, 1000);
 		}, 1000);


### PR DESCRIPTION
After updating the text send a `textInput` event appending a newline to
it. This will cause some sites (at least StackOverflow.com) to update
their preview of the rendered content.  Unfortunately this also causes
an extra newline to be added to the end of the area, but there tends to
be an extra one there anyway.
