### PR TITLE
Add autoload cookie for edit-server-start

### DIFF
--- a/servers/edit-server.el
+++ b/servers/edit-server.el
@@ -279,6 +279,7 @@ send a response back to the client."
 avoid the user being prompted to kill the edit-server process."
       (or edit-server-clients (edit-server-stop)))
 
+;;;###autoload
 (defun edit-server-start (&optional verbose)
   "Start the edit server.
 


### PR DESCRIPTION
With this addition, users who have installed edit-server from a package will be able to interactively start the edit server without first needing to explicitly load the library.
