### PR TITLE
fix file name too long

### DIFF
--- a/servers/pycl.py
+++ b/servers/pycl.py
@@ -24,6 +24,7 @@ import tempfile, time
 import os, sys, re
 import stat
 import optparse
+import hashlib
 from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
 
 _default_port = 9292
@@ -75,7 +76,11 @@ class Handler(BaseHTTPRequestHandler):
 				print "url:", url
 				prefix = "chrome_"
 				if url:
-					prefix += re.sub("[^.\w]", "_", re.sub("^.*?//","",url))
+					parts = urlparse.urlparse(url)
+					host = parts.netloc.split(':')[0]
+					name = os.path.basename(parts.path) or os.path.basename(os.path.dirname(parts.path))
+					m = hashlib.sha1(url).hexdigest( )
+					prefix += "{0}_{1}_{2}".format(host, name, m)
 				prefix += "_"
 				if temp_has_delete==True:
 					f = tempfile.NamedTemporaryFile(


### PR DESCRIPTION
I had problems with server crashing because the file name was too
long.

I like getting hints about hostname and path, but don't like getting
errors depending on length of the url.  This approach uses sha1 digest
of the original url to create a shorter version, while retaining the
previous approach of appending.  Helps edit documents like this:

```
http://interactive.blockdiag.com/seqdiag
```
