### PR TITLE
added edit-server-started-hook for manipulating frame/window

### DIFF
--- a/servers/README
+++ b/servers/README
@@ -32,12 +32,13 @@ your ~/.emacs.
 Hooks
 =====
 
-edit-server.el provides three hooks for customising behaviour when edit
+edit-server.el provides four hooks for customising behaviour when edit
 requests are being made. These are:
 
 * edit-server-start-hook - called when the editing buffer is created
 * edit-server-started-hook - called after editing window is created
-* edit-server-done-hook - called when just before the text returned
+* edit-server-done-hook - called just before the text is returned
+* edit-server-buffer-closed-hook - called after editing buffer is closed
 
 The edit-server-start-hook should be used for setting any major/minor
 modes. The edit-server-started-hook can be used for manipulating the

--- a/servers/edit-server.el
+++ b/servers/edit-server.el
@@ -98,6 +98,12 @@ Current buffer holds the text that is about to be sent back to the client."
   :group 'edit-server
   :type 'hook)
 
+(defcustom edit-server-buffer-closed-hook nil
+  "Hook run after text is sent back to the client and the editing buffer
+has been closed."
+  :group 'edit-server
+  :type 'hook)
+
 (defcustom edit-server-start-hook nil
   "Hook run when starting a editing buffer.  Current buffer is
 the fully prepared editing buffer.  Use this hook to enable
@@ -642,7 +648,8 @@ When called interactively, use prefix arg to abort editing."
       (unless nokill
         ; don't run abort twice in a row.
         (remove-hook 'kill-buffer-hook 'edit-server-abort*)
-	(kill-buffer buffer))
+	(kill-buffer buffer)
+	(run-hooks 'edit-server-buffer-closed-hook))
       (edit-server-kill-client proc))))
 
 ;; edit-server-save uses the iterative edit-server option (send a


### PR DESCRIPTION
Since the edit-server-start-hook is run before the editing frame/window
has been created, a new hook edit-server-started-hook was created which
is run after the frame/window has been created.  This allows hooks that
rearrange windows or otherwise manipulate the editing frame/window.
