### PR TITLE
fix new-frame not raised in MacOSX

### DIFF
--- a/servers/edit-server.el
+++ b/servers/edit-server.el
@@ -486,6 +486,7 @@ frame."
 				 '(1 0 0)))
 	(raise-frame new-frame)
 	(set-window-buffer (frame-selected-window new-frame) buffer)
+        (select-frame-set-input-focus (window-frame (selected-window)))
 	new-frame)
     (select-frame-set-input-focus (window-frame (selected-window)))
     (pop-to-buffer buffer)


### PR DESCRIPTION
I tested under MacOSX 10.9.1, Emacs 24.1.
When `edit-server-new-frame` is `t`, the new frame will be opened but not raised to the front, and not focus on Emacs.app. Though, it works when it's `nil`.
