### PR TITLE
Fix deprecated and Firefox incompatible webextension api calls

### DIFF
--- a/fancy-settings/source/settings.js
+++ b/fancy-settings/source/settings.js
@@ -11,7 +11,7 @@ function localMessageHandler(msg, port) {
 
 // Test for the presence of an Edit Server
 function test_server() {
-	var port = chrome.extension.connect();
+	var port = browser.runtime.connect();
 	port.onMessage.addListener(localMessageHandler);
 	port.postMessage({msg: "test"});
 }

--- a/javascript/context_menu.js
+++ b/javascript/context_menu.js
@@ -56,7 +56,7 @@
 		sendResponse({});
 	}
 
-	chrome.extension.onRequest.addListener(processRequest);
+	browser.runtime.onMessage.addListener(processRequest);
 
 })();
 

--- a/javascript/textareas.js
+++ b/javascript/textareas.js
@@ -10,7 +10,7 @@
  */
 
 var editImgURL = chrome.extension.getURL("icons/gumdrop.png");
-var port = chrome.extension.connect();
+var port = browser.runtime.connect();
 
 // For findTextAreas
 var page_edit_id = 0;
@@ -203,8 +203,10 @@ function updateTextArea(id, content) {
 	tracker.text.selectionStart = content.length;
 	// send a textInputEvent to append a newline
 	event = document.createEvent("TextEvent");
-	event.initTextEvent('textInput', true, true, null, '\n', 0);
-	tracker.text.dispatchEvent(event);
+	if (event.initTextEvent !== undefined) {
+		event.initTextEvent('textInput', true, true, null, '\n', 0);
+		tracker.text.dispatchEvent(event);
+	}
 
 	window.setTimeout(function() {
             // reset the text to the original without newline
@@ -401,8 +403,8 @@ function localMessageHandler(msg, port) {
 // as well as direct messages from main extension.
 
 port.onMessage.addListener(localMessageHandler);
-chrome.extension.onConnect.addListener(function(iport) {
-	iport.onMessage.addListener(localMessageHandler);
+browser.runtime.onConnect.addListener(function(iport) {
+    iport.onMessage.addListener(localMessageHandler);
 });
 
 /*
@@ -426,6 +428,6 @@ document.addEventListener("contextmenu", (function(event) {
                 id: elem.getAttribute("edit_id")
             }
         };
-        chrome.extension.sendRequest(request);
+        browser.runtime.sendMessage(request);
     }
 }));

--- a/javascript/xmlcomms.js
+++ b/javascript/xmlcomms.js
@@ -264,4 +264,4 @@ function localMessageHandler(port)
 }
 
 // Hook up whenever someone connects to the extension comms port
-chrome.extension.onConnect.addListener(localMessageHandler);
+browser.runtime.onConnect.addListener(localMessageHandler);

--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,10 @@
 	{
 		"128" : "icons/emacs.png"
 	},
-	"options_page": "fancy-settings/source/index.html",
+	"options_ui": {
+		"page": "fancy-settings/source/index.html",
+		"open_in_tab": true
+	},
         "web_accessible_resources": [
 	    "icons/gumdrop.png",
 	    "icons/emacs23-16x16-red.png"
@@ -30,9 +33,9 @@
 			"matches": ["http://*/*", "https://*/*", "file://*/*"],
 			"css": ["css/textareas.css"],
 			"js": [
-			    "javascript/textareas.js",
 			    "lib/jquery-1.7.min.js",
 			    "lib/jquery.color.min.js",
+			    "javascript/textareas.js",
 			    "lib/mutation_summary.js"
 			],
 			"run_at": "document_idle",


### PR DESCRIPTION
I updated some deprecated webextension api calls
(See https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Browser_support_for_JavaScript_APIs#runtime)
to make it work in Firefox.

I didn't test again in Chrome but it should work just like before
and I don't have Windows but I would guess it works now in Edge as well.

I couldn't find a replacement for `event.initTextEvent`, so
this part is Chrome only but the extension works just fine
without it (I probably wouldn't want an extra newline anyway?!).

If you want to upload the extension to Mozilla we would need
to upgrade jQuery to 2.xx since 1.xx is not allowed for extensions.
Do you want to upload to AMO or should(/can) I?

BTW, I see there's quite a mix of real tabs and spaces in the files
and sometimes just wrongly indented.

Can I run the code through [prettier](https://github.com/prettier/prettier) with
your preferred settings (whitespace, 4 spaces?) and make a pull request for that?


Thanks for the nice plugin.