### PR TITLE
dispatch "input" event to textarea after update

### DIFF
--- a/javascript/textareas.js
+++ b/javascript/textareas.js
@@ -125,6 +125,10 @@ function textAreaTracker(text)
             this.text.innerHTML = new_text;
         } else {
             this.text.value = new_text;
+            // fix for some sites that maintain and submit a shadow copy of the text area
+            // that gets updated on "input" events to the real one; e.g. fastmail.fm's
+            // "Compose Message" page.
+            this.text.dispatchEvent(new Event("input"));
         }
     };
 }


### PR DESCRIPTION
(proposed fix for #134)

Some sites (looking at you, fastmail.fm) apparently maintain a shadow
copy of a textarea's contents, updating it from `change` events on the
real textarea.  Unfortunately, when `emacs_chrome` directly updates
the real textarea with text received from emacs, the shadow copy does
not see these changes.  The user (me) is then surprised to see that
upon submitting the web page (i.e. `Send`ing the email), the edits
made in emacs have disappeared, even though they were visible in the
textarea.

This commit dispatches an `input` event to the textarea after its
value has been set with the new contents received from emacs, and
fixes the problem (for https://fastmail.fm, at least).