### PR TITLE
Delete window when done editing

### DIFF
--- a/servers/edit-server.el
+++ b/servers/edit-server.el
@@ -643,7 +643,9 @@ When called interactively, use prefix arg to abort editing."
       (unless nokill
         ;; don't run abort twice in a row.
         (remove-hook 'kill-buffer-hook 'edit-server-abort*)
-	(kill-buffer buffer))
+	(kill-buffer buffer)
+	(unless edit-server-frame
+	  (delete-window)))
       (edit-server-kill-client proc))))
 
 ;; edit-server-save uses the iterative edit-server option (send a


### PR DESCRIPTION
When `edit-server-new-frame` is set to `nil`
edit-server will create a new window (`pop-to-buffer`) but
when done editing leaves the opened window around and just kills the
buffer.

I recently switched from i3 to exwm so I don't want new
frames but everything only in new windows and that's why
I saw this.