### PR TITLE
Fix issue that `edit-server-make-frame` creates GUI window frame when…

### DIFF
--- a/servers/edit-server.el
+++ b/servers/edit-server.el
@@ -467,7 +467,7 @@ non-nil, then STRING is also echoed to the message line."
   "Create a frame for editing and return it."
   (let ((disp (getenv "DISPLAY")))
     (edit-server-log nil "Creating frame for %s/%s" window-system disp)
-    (if (or (memq window-system '(ns mac))
+    (if (or (memq window-system '(ns mac nil))
             (= 0 (length disp)))
       ;; Aquamacs, Emacs NS, Emacs (experimental) Mac port, termcap.
       ;; matching (nil) avoids use of DISPLAY from TTY environments.


### PR DESCRIPTION
… running emacs with -nw


<img width="1280" alt="edit-server-make-frame-creates-gui-window-frame-when-running-emacs-with-nw" src="https://user-images.githubusercontent.com/2653486/35140952-11a02d42-fd34-11e7-8b2e-7f3223906ce7.png">
