### PR TITLE
Use a settings to allow editing textarea with spellcheck disabled.

### DIFF
--- a/fancy-settings/source/manifest.js
+++ b/fancy-settings/source/manifest.js
@@ -59,6 +59,13 @@ this.manifest = {
 	    "type": "checkbox",
 	    "label": "Allow double click on textarea to invoke editor"
 	},
+	{
+            "tab": "Configuration",
+            "group": "Interface",
+	    "name": "enable_for_no_spellcheck",
+	    "type": "checkbox",
+	    "label": "Allow editing textareas where spell check has been disabled"
+	},
         {
             "tab": "Test",
             "group": "Test",

--- a/javascript/textareas.js
+++ b/javascript/textareas.js
@@ -28,6 +28,7 @@ var pageTextAreas = [];
 var enable_button = true;
 var enable_dblclick = false;
 var enable_debug = false;
+var enable_for_no_spellcheck = false;
 
 // Decorate console.log so that it only logs
 // when the enable_debug setting is true
@@ -194,11 +195,14 @@ function tagTextArea(text)
     }
 
     // If spellcheck is turned off, usually it's just for quick editing, e.g. To: fields in gmail
-    var spellcheck = t.attr("spellcheck");
-    if (spellcheck && spellcheck == "false" &&
-        t.prop("tagName") === "TEXTAREA") {
-        console.log("tagTextArea: skipping spellcheck disabled textarea");
-        return;
+    if (!enable_for_no_spellcheck) {
+        var spellcheck = t.attr("spellcheck");
+
+        if (spellcheck && spellcheck == "false" &&
+            t.prop("tagName") === "TEXTAREA") {
+            console.log("tagTextArea: skipping spellcheck disabled textarea");
+            return;
+        }
     }
 
     // No edit for read-only text
@@ -381,6 +385,7 @@ function localMessageHandler(msg, port) {
         enable_button = msg.enable_button;
         enable_dblclick = msg.enable_dblclick;
         enable_debug = msg.enable_debug;
+        enable_for_no_spellcheck  = msg.enable_for_no_spellcheck;
 
         var all = editable_selectors.join(",");
         $(all).each(function() {

--- a/javascript/xmlcomms.js
+++ b/javascript/xmlcomms.js
@@ -17,7 +17,8 @@ var settings = new Store("settings", {
     "edit_server_disable_settings": false,
     "enable_button": true,
     "enable_dblclick": false,
-    "enable_debug": false
+    "enable_debug": false,
+    "enable_for_no_spellcheck": false
 });
 
 // Decorate console.log so that it only logs
@@ -250,7 +251,8 @@ function handleConfigMessages(msg, tab_port)
         msg: "config",
         enable_button: settings.get("enable_button"),
         enable_dblclick: settings.get("enable_dblclick"),
-        enable_debug: settings.get("enable_debug")
+        enable_debug: settings.get("enable_debug"),
+        enable_for_no_spellcheck: settings.get("enable_for_no_spellcheck")
     };
     tab_port.postMessage(config_msg);
 }


### PR DESCRIPTION
I have a few use case where text areas are used with spellchecking disabled but where I still want to edit with emacs (mostly programming snippets). I made a settings to allow editing those.