### PR TITLE
Specify `lexical-binding' explicitly

### DIFF
--- a/servers/edit-server.el
+++ b/servers/edit-server.el
@@ -1,4 +1,4 @@
-;;; edit-server.el --- server that responds to edit requests from Chrome
+;;; edit-server.el --- server that responds to edit requests from Chrome  -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2009-2013  Alex Bennée
 ;; Copyright (C) 2010-2011  Riccardo Murri


### PR DESCRIPTION
See https://www.emacswiki.org/emacs/DynamicBindingVsLexicalBinding for more about the motivation for this change.  Without this change, warnings like this will appear in the "*Warnings*" buffer at startup:

  ⛔ Warning (lexical-binding): File .../emacs_chrome/servers/edit-server.el
  lacks `lexical-binding' directive on its first line